### PR TITLE
Fix pin deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 *.pyc
 fuzzer-code/*.json
 fuzzer-code/*.taint
-pin-*
 pin*
 fuzzer-code/data
 fuzzer-code/outd
@@ -49,3 +48,7 @@ libdft64/tools/junk.*
 *.swp
 *~
 *.swo
+
+# Temp output #
+###############
+vutemp

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 fuzzer-code/*.json
 fuzzer-code/*.taint
 pin-*
+pin*
 fuzzer-code/data
 fuzzer-code/outd
 fuzzer-code/inter

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,3 @@ libdft64/tools/junk.*
 *.swp
 *~
 *.swo
-
-# Temp output #
-###############
-vutemp

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ libdft64/tools/junk.*
 *.swp
 *~
 *.swo
+
+# Temp output #
+###############
+vutemp

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please see wikiHOWTO.md for a step-by-step procedure to run the VUzzer. This fil
 The requirements for running VUzzer64 are:
 
 *  A C++11 compiler and unix build utilities (e.g. GNU Make). 
-*  Version 3.7 of Intel Pin. 
+*  Version 3.20 of Intel Pin. 
 *  EWAGBoolArray 0.4.0: https://github.com/lemire/EWAHBoolArray/releases/tag/0.4.0 - To install it in your system just copy headers file(/path/to/EWAHBoolArray-0.4.0/headers)
    in /usr/include folder.
 *  BitMagic: http://bmagic.sourceforge.net/ - To install it in your system do ```sudo apt-get install bmagic```

--- a/fuzzer-code/bbcounts2.cpp
+++ b/fuzzer-code/bbcounts2.cpp
@@ -162,9 +162,9 @@ VOID Trace(TRACE trace, VOID *v)
         INS tail = BBL_InsTail(bbl);
         if( INS_IsCall(tail) )
         {
-            if( INS_IsDirectBranchOrCall(tail))
+            if( INS_IsDirectControlFlow(tail))
             {
-                ADDRINT target = INS_DirectBranchOrCallTargetAddress(tail);
+                ADDRINT target = INS_DirectControlFlowTargetAddress(tail);
                 INS_InsertPredicatedCall(tail, IPOINT_BEFORE, AFUNPTR(call_direct), IARG_ADDRINT, target, IARG_END);
             }
             else

--- a/libdft64/libdft_core.cpp
+++ b/libdft64/libdft_core.cpp
@@ -3614,7 +3614,7 @@ ins_inspect(INS ins)
 						IARG_UINT32, REG_INDX(reg_dst),
 						IARG_MEMORYREAD_EA,
 						IARG_END);
-				else if (INS_MemoryWriteSize(ins) ==
+				else if (INS_MemoryOperandSize(ins, 0) ==
 						BIT2BYTE(MEM_WORD_LEN)){
 					if(REG_is_gr64(reg_dst))
 					INS_InsertCall(ins,
@@ -3782,7 +3782,7 @@ ins_inspect(INS ins)
 						IARG_UINT32, REG_INDX(reg_dst),
 						IARG_MEMORYREAD_EA,
 						IARG_END);
-				else if (INS_MemoryWriteSize(ins) ==
+				else if (INS_MemoryOperandSize(ins, 0) ==
 						BIT2BYTE(MEM_WORD_LEN)){
 					if(REG_is_gr64(reg_dst))
 					INS_InsertCall(ins,
@@ -3829,7 +3829,7 @@ ins_inspect(INS ins)
 		case XED_ICLASS_IDIV:
 		case XED_ICLASS_MUL:
 			if (INS_OperandIsMemory(ins, OP_0))
-				switch (INS_MemoryWriteSize(ins)) {
+				switch (INS_MemoryOperandSize(ins, 0)) {
 					case BIT2BYTE(MEM_64BIT_LEN):
 					INS_InsertCall(ins,
 						IPOINT_BEFORE,
@@ -3916,7 +3916,7 @@ ins_inspect(INS ins)
 		case XED_ICLASS_IMUL:
 			if (INS_OperandIsImplicit(ins, OP_1)) {
 				if (INS_OperandIsMemory(ins, OP_0))
-				switch (INS_MemoryWriteSize(ins)) {
+				switch (INS_MemoryOperandSize(ins, 0)) {
 					case BIT2BYTE(MEM_64BIT_LEN):
 					INS_InsertCall(ins,
 						IPOINT_BEFORE,
@@ -5119,7 +5119,7 @@ ins_inspect(INS ins)
 						IARG_END);
 			}
 			else if (INS_OperandIsMemory(ins, OP_0)) {
-				if (INS_MemoryWriteSize(ins) ==
+				if (INS_MemoryOperandSize(ins, 0) ==
 						BIT2BYTE(MEM_64BIT_LEN))
 					INS_InsertCall(ins,
 						IPOINT_BEFORE,
@@ -5129,7 +5129,7 @@ ins_inspect(INS ins)
 						IARG_MEMORYREAD_EA,
 						IARG_END);
 
-				else if (INS_MemoryWriteSize(ins) ==
+				else if (INS_MemoryOperandSize(ins, 0) ==
 						BIT2BYTE(MEM_LONG_LEN))
 					INS_InsertCall(ins,
 						IPOINT_BEFORE,
@@ -5181,7 +5181,7 @@ ins_inspect(INS ins)
 						IARG_END);
 			}
 			else if (INS_OperandIsMemory(ins, OP_0)) {
-				if (INS_MemoryWriteSize(ins) ==
+				if (INS_MemoryOperandSize(ins, 0) ==
 						BIT2BYTE(MEM_64BIT_LEN))
 					INS_InsertCall(ins,
 						IPOINT_BEFORE,
@@ -5190,7 +5190,7 @@ ins_inspect(INS ins)
 						IARG_MEMORYWRITE_EA,
 						IARG_MEMORYREAD_EA,
 						IARG_END);
-				else if (INS_MemoryWriteSize(ins) ==
+				else if (INS_MemoryOperandSize(ins, 0) ==
 						BIT2BYTE(MEM_LONG_LEN))
 					INS_InsertCall(ins,
 						IPOINT_BEFORE,
@@ -5682,7 +5682,7 @@ ins_inspect(INS ins)
 			}
 			else if(INS_OperandIsReg(ins, OP_0)){
 				reg_dst = INS_OperandReg(ins, OP_0); 
-				if (INS_MemoryReadSize(ins) == BIT2BYTE(MEM_64BIT_LEN))
+				if (INS_MemoryOperandSize(ins, 0) == BIT2BYTE(MEM_64BIT_LEN))
 					INS_InsertCall(ins,
 						IPOINT_BEFORE,
 						(AFUNPTR)m2r_xfer_opq,
@@ -5702,7 +5702,7 @@ ins_inspect(INS ins)
 						IARG_END);
 			}else{
 				reg_src = INS_OperandReg(ins, OP_1); 
-				if (INS_MemoryReadSize(ins) == BIT2BYTE(MEM_64BIT_LEN))
+				if (INS_MemoryOperandSize(ins, 0) == BIT2BYTE(MEM_64BIT_LEN))
 					INS_InsertCall(ins,
 						IPOINT_BEFORE,
 						(AFUNPTR)r2m_xfer_opq,


### PR DESCRIPTION
It seems like pin has deprecated some of the functions used by VUzzer. It seems like the old versions of pin (e..g, 3.7), which might have used these functions, are not easily accessible. This patch changes only 2 API calls in bbcounts2.cpp.